### PR TITLE
[FIX] OD18-125, web_remember_tree_column_width: fix undefined `this`

### DIFF
--- a/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
+++ b/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
@@ -15,7 +15,6 @@ import {useDebounced} from "@web/core/utils/timing";
  * of a _resizing variable reference and an onStartResize function reference.
  */
 export function useMagicColumnWidths(tableRef, getState, orig) {
-    const onStartResizeOrig = orig.onStartResize;
     const renderer = useComponent();
 
     /**
@@ -25,7 +24,7 @@ export function useMagicColumnWidths(tableRef, getState, orig) {
      */
     function onStartResize(evstart) {
         // Call original method
-        const res = onStartResizeOrig(evstart);
+        const res = this.columnWidths.onStartResizeOrig(evstart);
         const resizeStoppingEvents = ["keydown", "pointerdown", "pointerup"];
 
         // Mouse or keyboard events : stop resize
@@ -101,6 +100,7 @@ export function useMagicColumnWidths(tableRef, getState, orig) {
         useExternalListener(window, "resize", debouncedResizeCallback);
     }
 
+    orig.onStartResizeOrig = orig.onStartResize;
     orig.onStartResize = onStartResize;
     return orig;
 }


### PR DESCRIPTION
Fixes
```
Uncaught Javascript Error > Cannot read properties of undefined (reading 'isRTL')
```

when trying to resizing a column in a list view.

Caused by upstream change https://github.com/odoo/odoo/pull/210559

OCA PR: `https://github.com/OCA/web/pull/3177` (backticks om niet te crosslinken vanaf de OCA PR naar deze)