### PR TITLE
[REV] OD-931, revert "[FIX] OD18-133, quatra_dispatching: Expose hasSelecotrUsedOffset"

### DIFF
--- a/web_remember_tree_column_width/README.rst
+++ b/web_remember_tree_column_width/README.rst
@@ -36,13 +36,6 @@ grouping, or reordering.
 .. contents::
    :local:
 
-Known issues / Roadmap
-======================
-
-In certain cases, an event may pass a th element that cannot be used to
-retrieve the corresponding td element. When this happens, the modified
-column width is not stored.
-
 Bug Tracker
 ===========
 
@@ -64,13 +57,13 @@ Authors
 Contributors
 ------------
 
-- Francisco Javier Luna Vázquez <fluna@vauxoo.com>
-- Tomás Álvarez <tomas@vauxoo.com>
-- `Komit <https://komit-consulting.com/>`__:
+-  Francisco Javier Luna Vázquez <fluna@vauxoo.com>
+-  Tomás Álvarez <tomas@vauxoo.com>
+-  `Komit <https://komit-consulting.com/>`__:
 
-  - Cuong Nguyen Mtm <cuong.nmtm@komit-consulting.com>
+   -  Cuong Nguyen Mtm <cuong.nmtm@komit-consulting.com>
 
-- Jasmin Solanki <jasmin.solanki@forgeflow.com>
+-  Jasmin Solanki <jasmin.solanki@forgeflow.com>
 
 Maintainers
 -----------

--- a/web_remember_tree_column_width/readme/ROADMAP.md
+++ b/web_remember_tree_column_width/readme/ROADMAP.md
@@ -1,1 +1,0 @@
-In certain cases, an event may pass a th element that cannot be used to retrieve the corresponding td element. When this happens, the modified column width is not stored.

--- a/web_remember_tree_column_width/static/description/index.html
+++ b/web_remember_tree_column_width/static/description/index.html
@@ -375,24 +375,17 @@ grouping, or reordering.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h1>
-<p>In certain cases, an event may pass a th element that cannot be used to
-retrieve the corresponding td element. When this happens, the modified
-column width is not stored.</p>
-</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/web/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -400,15 +393,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
 <li>Vauxoo</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>Francisco Javier Luna Vázquez &lt;<a class="reference external" href="mailto:fluna&#64;vauxoo.com">fluna&#64;vauxoo.com</a>&gt;</li>
 <li>Tomás Álvarez &lt;<a class="reference external" href="mailto:tomas&#64;vauxoo.com">tomas&#64;vauxoo.com</a>&gt;</li>
@@ -420,7 +413,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
+++ b/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
@@ -22,13 +22,13 @@ export function useMagicColumnWidths(tableRef, getState, orig) {
      * We call super, then add event listeners for our own stopResize handler
      * which stores column widths in the brower's localstorage.
      */
-    function onStartResize(evstart) {
+    function onStartResize(ev) {
         // Call original method
-        const res = this.columnWidths.onStartResizeOrig(evstart);
+        const res = this.columnWidths.onStartResizeOrig(ev);
         const resizeStoppingEvents = ["keydown", "pointerdown", "pointerup"];
 
         // Mouse or keyboard events : stop resize
-        const stopResize = (evstop) => {
+        const stopResize = (evstart) => (evstop) => {
             // Ignores the 'left mouse button down' event as it used to start resizing
             if (evstop.type === "pointerdown" && evstop.button === 0) {
                 return;
@@ -36,7 +36,7 @@ export function useMagicColumnWidths(tableRef, getState, orig) {
             evstop.preventDefault();
             evstop.stopPropagation();
 
-            const th = evstop.target.closest("th");
+            const th = evstart.target.closest("th");
             if (th === null || th === undefined) {
                 return;
             }
@@ -51,11 +51,14 @@ export function useMagicColumnWidths(tableRef, getState, orig) {
                 );
             }
             for (const eventType of resizeStoppingEvents) {
-                window.removeEventListener(eventType, stopResize);
+                window.removeEventListener(eventType, evstart.stopResizeWrapper);
             }
         };
+        // Patch the event listener method onto the event that is being passed
+        // to it, so that we can remove it from within the method.
+        ev.stopResizeWrapper = stopResize(ev);
         for (const eventType of resizeStoppingEvents) {
-            window.addEventListener(eventType, stopResize);
+            window.addEventListener(eventType, ev.stopResizeWrapper);
         }
         return res;
     }

--- a/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
+++ b/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
@@ -16,8 +16,6 @@ import {useDebounced} from "@web/core/utils/timing";
  */
 export function useMagicColumnWidths(tableRef, getState, orig) {
     const renderer = useComponent();
-    // This variable is added for compatibility with our custom rowno-in-tree widget
-    const hasSelectorUsedOffset = renderer.constructor.hasSelectorUsedOffset || 1;
 
     /**
      * Override on onStartResize as returned from upstream's useMagicColumnWidths.
@@ -70,7 +68,7 @@ export function useMagicColumnWidths(tableRef, getState, orig) {
         const headers = [...table.querySelectorAll("thead th")];
         const state = getState();
         const resModel = state.model.config.resModel;
-        const columnOffset = state.hasSelectors ? hasSelectorUsedOffset : 0;
+        const columnOffset = state.hasSelectors ? 1 : 0;
         headers.forEach((el, elIndex) => {
             var column = state.columns[elIndex - columnOffset];
             const fieldName = (column && column.name) || "";


### PR DESCRIPTION
This reverts commit e9c9980a6ac3f89c513fda5559a4ea44a3d15fa7.

Obsoleted by a new implementation of the row number widget.